### PR TITLE
Feature check compatibility

### DIFF
--- a/Mist.xcodeproj/project.pbxproj
+++ b/Mist.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		39F6D33F28447A3C003C2F25 /* DownloadFirmwareCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D33E28447A3C003C2F25 /* DownloadFirmwareCommand.swift */; };
 		39F6D34128447EF4003C2F25 /* ListFirmwareOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D34028447EF4003C2F25 /* ListFirmwareOptions.swift */; };
 		39F6D3432844833E003C2F25 /* DownloadFirmwareOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D3422844833E003C2F25 /* DownloadFirmwareOptions.swift */; };
+		39F6D34528465006003C2F25 /* Hardware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D34428465006003C2F25 /* Hardware.swift */; };
 		570D5091260034E10066E4C9 /* Catalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570D5090260034E10066E4C9 /* Catalog.swift */; };
 		5744140025F85EF300DE5540 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574413FF25F85EF300DE5540 /* main.swift */; };
 		5744140925F8603300DE5540 /* Mist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5744140825F8603300DE5540 /* Mist.swift */; };
@@ -86,6 +87,7 @@
 		39F6D33E28447A3C003C2F25 /* DownloadFirmwareCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFirmwareCommand.swift; sourceTree = "<group>"; };
 		39F6D34028447EF4003C2F25 /* ListFirmwareOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListFirmwareOptions.swift; sourceTree = "<group>"; };
 		39F6D3422844833E003C2F25 /* DownloadFirmwareOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFirmwareOptions.swift; sourceTree = "<group>"; };
+		39F6D34428465006003C2F25 /* Hardware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hardware.swift; sourceTree = "<group>"; };
 		570D5090260034E10066E4C9 /* Catalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Catalog.swift; sourceTree = "<group>"; };
 		574413FC25F85EF300DE5540 /* mist */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = mist; sourceTree = BUILT_PRODUCTS_DIR; };
 		574413FF25F85EF300DE5540 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 			children = (
 				57D1357725F9F308003467B2 /* Downloader.swift */,
 				57D1358E25FA4027003467B2 /* Generator.swift */,
+				39F6D34428465006003C2F25 /* Hardware.swift */,
 				57D1357A25F9F716003467B2 /* HTTP.swift */,
 				57D1358B25FA3CE5003467B2 /* Installer.swift */,
 				57D1359625FB1B97003467B2 /* PrettyPrint.swift */,
@@ -349,6 +352,7 @@
 				5744140025F85EF300DE5540 /* main.swift in Sources */,
 				390B7199281B92AA00875374 /* Validator.swift in Sources */,
 				5744141725F8659D00DE5540 /* ListInstallerCommand.swift in Sources */,
+				39F6D34528465006003C2F25 /* Hardware.swift in Sources */,
 				3967935F26D74BAC00DC2D2D /* DownloadCommand.swift in Sources */,
 				57D1358225F9F8E5003467B2 /* Package.swift in Sources */,
 				57D1359725FB1B97003467B2 /* PrettyPrint.swift in Sources */,

--- a/Mist/Commands/Download/DownloadFirmwareCommand.swift
+++ b/Mist/Commands/Download/DownloadFirmwareCommand.swift
@@ -31,7 +31,7 @@ struct DownloadFirmwareCommand: ParsableCommand {
         !options.quiet ? PrettyPrint.printHeader("SEARCH") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Searching for macOS download '\(options.searchString)'...") : Mist.noop()
 
-        guard let firmware: Firmware = HTTP.firmware(from: HTTP.retrieveFirmwares(includeBetas: options.includeBetas), searchString: options.searchString) else {
+        guard let firmware: Firmware = HTTP.firmware(from: HTTP.retrieveFirmwares(includeBetas: options.includeBetas, compatible: options.compatible), searchString: options.searchString) else {
             !options.quiet ? PrettyPrint.print("No macOS Firmware found with '\(options.searchString)', exiting...", prefix: .ending) : Mist.noop()
             return
         }
@@ -67,6 +67,7 @@ struct DownloadFirmwareCommand: ParsableCommand {
         }
 
         !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...") : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Only include compatible firmwares will be '\(options.compatible)'...") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Output directory will be '\(options.outputDirectory)'...") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Temporary directory will be '\(options.temporaryDirectory)'...") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Force flag\(options.force ? " " : " has not been ")set, existing files will\(options.force ? " " : " not ")be overwritten...") : Mist.noop()

--- a/Mist/Commands/Download/DownloadFirmwareOptions.swift
+++ b/Mist/Commands/Download/DownloadFirmwareOptions.swift
@@ -37,6 +37,11 @@ struct DownloadFirmwareOptions: ParsableArguments {
     """)
     var includeBetas: Bool = false
 
+    @Flag(name: .long, help: """
+    Only include macOS Firmwares that are compatible with this Mac in search results.
+    """)
+    var compatible: Bool = false
+
     @Flag(name: .shortAndLong, help: """
     Force overwriting existing macOS Downloads matching the provided filename(s).
     Note: Downloads will fail if an existing file is found and this flag is not provided.

--- a/Mist/Commands/Download/DownloadFirmwareOptions.swift
+++ b/Mist/Commands/Download/DownloadFirmwareOptions.swift
@@ -33,7 +33,7 @@ struct DownloadFirmwareOptions: ParsableArguments {
     var searchString: String
 
     @Flag(name: [.customShort("b"), .long], help: """
-    Include beta macOS Firmwares / Installers in search results.
+    Include beta macOS Firmwares in search results.
     """)
     var includeBetas: Bool = false
 

--- a/Mist/Commands/Download/DownloadInstallerCommand.swift
+++ b/Mist/Commands/Download/DownloadInstallerCommand.swift
@@ -40,7 +40,7 @@ struct DownloadInstallerCommand: ParsableCommand {
             catalogURLs = [catalogURL]
         }
 
-        let retrievedProducts: [Product] = HTTP.retrieveProducts(from: catalogURLs, includeBetas: options.includeBetas)
+        let retrievedProducts: [Product] = HTTP.retrieveProducts(from: catalogURLs, includeBetas: options.includeBetas, compatible: options.compatible)
 
         guard let product: Product = HTTP.product(from: retrievedProducts, searchString: options.searchString) else {
             !options.quiet ? PrettyPrint.print("No macOS Installer found with '\(options.searchString)', exiting...", prefix: .ending) : Mist.noop()
@@ -85,6 +85,7 @@ struct DownloadInstallerCommand: ParsableCommand {
         }
 
         !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...") : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Only include compatible installers will be '\(options.compatible)'...") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Cache downloads will be '\(options.cacheDownloads)'...") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Output directory will be '\(options.outputDirectory)'...") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Temporary directory will be '\(options.temporaryDirectory)'...") : Mist.noop()

--- a/Mist/Commands/Download/DownloadInstallerOptions.swift
+++ b/Mist/Commands/Download/DownloadInstallerOptions.swift
@@ -47,6 +47,11 @@ struct DownloadInstallerOptions: ParsableArguments {
     """)
     var includeBetas: Bool = false
 
+    @Flag(name: .long, help: """
+    Only include macOS Installers that are compatible with this Mac in search results.
+    """)
+    var compatible: Bool = false
+
     @Option(name: .shortAndLong, help: """
     Override the default Software Update Catalog URLs.
     """)

--- a/Mist/Commands/Download/DownloadInstallerOptions.swift
+++ b/Mist/Commands/Download/DownloadInstallerOptions.swift
@@ -43,7 +43,7 @@ struct DownloadInstallerOptions: ParsableArguments {
     var outputType: [DownloadOutputType]
 
     @Flag(name: [.customShort("b"), .long], help: """
-    Include beta macOS Firmwares / Installers in search results.
+    Include beta macOS Installers in search results.
     """)
     var includeBetas: Bool = false
 

--- a/Mist/Commands/List/ListFirmwareCommand.swift
+++ b/Mist/Commands/List/ListFirmwareCommand.swift
@@ -37,6 +37,10 @@ struct ListFirmwareCommand: ParsableCommand {
             firmwares = HTTP.firmwares(from: firmwares, searchString: searchString)
         }
 
+        if options.compatible {
+            firmwares = firmwares.filter { $0.compatible }
+        }
+
         if options.latest {
             if let firmware: Firmware = firmwares.first {
                 firmwares = [firmware]
@@ -45,7 +49,10 @@ struct ListFirmwareCommand: ParsableCommand {
 
         try export(firmwares.map { $0.dictionary }, options: options)
         !options.quiet ? PrettyPrint.print("Found \(firmwares.count) macOS Firmware(s) available for download\n", prefix: .ending) : Mist.noop()
-        try list(firmwares.map { $0.dictionary }, options: options)
+
+        if !firmwares.isEmpty {
+            try list(firmwares.map { $0.dictionary }, options: options)
+        }
     }
 
     /// Perform a series of validations on input data, throwing an error if the input data is invalid.
@@ -70,6 +77,8 @@ struct ListFirmwareCommand: ParsableCommand {
         !options.quiet ? PrettyPrint.print("Search only for latest (first) result will be '\(options.latest)'...") : Mist.noop()
 
         !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...") : Mist.noop()
+
+        !options.quiet ? PrettyPrint.print("Only include compatible firmwares will be '\(options.compatible)'...") : Mist.noop()
 
         if let path: String = options.exportPath {
 

--- a/Mist/Commands/List/ListFirmwareCommand.swift
+++ b/Mist/Commands/List/ListFirmwareCommand.swift
@@ -31,14 +31,10 @@ struct ListFirmwareCommand: ParsableCommand {
         try inputValidation(options)
         !options.quiet ? PrettyPrint.printHeader("SEARCH") : Mist.noop()
         !options.quiet ? PrettyPrint.print("Searching for macOS Firmware versions...") : Mist.noop()
-        var firmwares: [Firmware] = HTTP.retrieveFirmwares(includeBetas: options.includeBetas, quiet: options.quiet)
+        var firmwares: [Firmware] = HTTP.retrieveFirmwares(includeBetas: options.includeBetas, compatible: options.compatible, quiet: options.quiet)
 
         if let searchString: String = options.searchString {
             firmwares = HTTP.firmwares(from: firmwares, searchString: searchString)
-        }
-
-        if options.compatible {
-            firmwares = firmwares.filter { $0.compatible }
         }
 
         if options.latest {

--- a/Mist/Commands/List/ListFirmwareCommand.swift
+++ b/Mist/Commands/List/ListFirmwareCommand.swift
@@ -67,9 +67,7 @@ struct ListFirmwareCommand: ParsableCommand {
             !options.quiet ? PrettyPrint.print("List search string will be '\(string)'...") : Mist.noop()
         }
 
-        if options.latest {
-            !options.quiet ? PrettyPrint.print("Searching only for latest (first) result...") : Mist.noop()
-        }
+        !options.quiet ? PrettyPrint.print("Search only for latest (first) result will be '\(options.latest)'...") : Mist.noop()
 
         !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...") : Mist.noop()
 

--- a/Mist/Commands/List/ListFirmwareOptions.swift
+++ b/Mist/Commands/List/ListFirmwareOptions.swift
@@ -39,6 +39,11 @@ struct ListFirmwareOptions: ParsableArguments {
     """)
     var includeBetas: Bool = false
 
+    @Flag(name: .long, help: """
+    Only include macOS Firmwares that are compatible with this Mac in search results.
+    """)
+    var compatible: Bool = false
+
     @Option(name: [.customShort("e"), .customLong("export")], help: """
     Specify the path to export the list to one of the following formats:
     * /path/to/export.csv (CSV file)

--- a/Mist/Commands/List/ListFirmwareOptions.swift
+++ b/Mist/Commands/List/ListFirmwareOptions.swift
@@ -35,7 +35,7 @@ struct ListFirmwareOptions: ParsableArguments {
     var latest: Bool = false
 
     @Flag(name: [.customShort("b"), .long], help: """
-    Include beta macOS Firmwares / Installers in search results.
+    Include beta macOS Firmwares in search results.
     """)
     var includeBetas: Bool = false
 

--- a/Mist/Commands/List/ListInstallerCommand.swift
+++ b/Mist/Commands/List/ListInstallerCommand.swift
@@ -38,14 +38,10 @@ struct ListInstallerCommand: ParsableCommand {
             catalogURLs = [catalogURL]
         }
 
-        var products: [Product] = HTTP.retrieveProducts(from: catalogURLs, includeBetas: options.includeBetas, quiet: options.quiet)
+        var products: [Product] = HTTP.retrieveProducts(from: catalogURLs, includeBetas: options.includeBetas, compatible: options.compatible, quiet: options.quiet)
 
         if let searchString: String = options.searchString {
             products = HTTP.products(from: products, searchString: searchString)
-        }
-
-        if options.compatible {
-            products = products.filter { $0.compatible }
         }
 
         if options.latest {

--- a/Mist/Commands/List/ListInstallerCommand.swift
+++ b/Mist/Commands/List/ListInstallerCommand.swift
@@ -44,6 +44,10 @@ struct ListInstallerCommand: ParsableCommand {
             products = HTTP.products(from: products, searchString: searchString)
         }
 
+        if options.compatible {
+            products = products.filter { $0.compatible }
+        }
+
         if options.latest {
             if let product: Product = products.first {
                 products = [product]
@@ -74,11 +78,11 @@ struct ListInstallerCommand: ParsableCommand {
             !options.quiet ? PrettyPrint.print("List search string will be '\(string)'...") : Mist.noop()
         }
 
-        if options.latest {
-            !options.quiet ? PrettyPrint.print("Searching only for latest (first) result...") : Mist.noop()
-        }
+        !options.quiet ? PrettyPrint.print("Search only for latest (first) result will be '\(options.latest)'...") : Mist.noop()
 
         !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...") : Mist.noop()
+
+        !options.quiet ? PrettyPrint.print("Only include compatible installers will be '\(options.compatible)'...") : Mist.noop()
 
         if let path: String = options.exportPath {
 

--- a/Mist/Commands/List/ListInstallerCommand.swift
+++ b/Mist/Commands/List/ListInstallerCommand.swift
@@ -56,7 +56,10 @@ struct ListInstallerCommand: ParsableCommand {
 
         try export(products.map { $0.dictionary }, options: options)
         !options.quiet ? PrettyPrint.print("Found \(products.count) macOS Installer(s) available for download\n", prefix: .ending) : Mist.noop()
-        try list(products.map { $0.dictionary }, options: options)
+
+        if !products.isEmpty {
+            try list(products.map { $0.dictionary }, options: options)
+        }
     }
 
     /// Perform a series of validations on input data, throwing an error if the input data is invalid.

--- a/Mist/Commands/List/ListInstallerOptions.swift
+++ b/Mist/Commands/List/ListInstallerOptions.swift
@@ -36,9 +36,14 @@ struct ListInstallerOptions: ParsableArguments {
     var latest: Bool = false
 
     @Flag(name: [.customShort("b"), .long], help: """
-    Include beta macOS Firmwares / Installers in search results.
+    Include beta macOS Installers in search results.
     """)
     var includeBetas: Bool = false
+
+    @Flag(name: .long, help: """
+    Only include macOS Installers that are compatible with this Mac in search results.
+    """)
+    var compatible: Bool = false
 
     @Option(name: .shortAndLong, help: """
     Override the default Software Update Catalog URLs.

--- a/Mist/Extensions/Sequence+Extension.swift
+++ b/Mist/Extensions/Sequence+Extension.swift
@@ -10,6 +10,7 @@ import Yams
 
 extension Sequence where Iterator.Element == [String: Any] {
 
+    // swiftlint:disable:next function_body_length
     func firmwaresASCIIString() -> String {
 
         let signedHeading: String = "Signed"
@@ -18,6 +19,7 @@ extension Sequence where Iterator.Element == [String: Any] {
         let buildHeading: String = "Build"
         let sizeHeading: String = "Size"
         let dateHeading: String = "Date"
+        let compatibleHeading: String = "Compatible"
 
         let maximumSignedLength: Int = self.compactMap { $0["signed"] as? Bool }.map { $0 ? "True" : "False" }.maximumStringLength(comparing: signedHeading)
         let maximumNameLength: Int = self.compactMap { $0["name"] as? String }.maximumStringLength(comparing: nameHeading)
@@ -25,6 +27,7 @@ extension Sequence where Iterator.Element == [String: Any] {
         let maximumBuildLength: Int = self.compactMap { $0["build"] as? String }.maximumStringLength(comparing: buildHeading)
         let maximumSizeLength: Int = self.compactMap { $0["size"] as? Int64 }.map { $0.bytesString() }.maximumStringLength(comparing: sizeHeading)
         let maximumDateLength: Int = self.compactMap { $0["date"] as? String }.maximumStringLength(comparing: dateHeading)
+        let maximumCompatibleLength: Int = self.compactMap { $0["compatible"] as? Bool }.map { $0 ? "True" : "False" }.maximumStringLength(comparing: compatibleHeading)
 
         let signedPadding: Int = Swift.max(maximumSignedLength - signedHeading.count, 0)
         let namePadding: Int = Swift.max(maximumNameLength - nameHeading.count, 0)
@@ -32,10 +35,16 @@ extension Sequence where Iterator.Element == [String: Any] {
         let buildPadding: Int = Swift.max(maximumBuildLength - buildHeading.count, 0)
         let sizePadding: Int = Swift.max(maximumSizeLength - sizeHeading.count, 0)
         let datePadding: Int = Swift.max(maximumDateLength - dateHeading.count, 0)
+        let compatiblePadding: Int = Swift.max(maximumCompatibleLength - compatibleHeading.count, 0)
 
         let columns: [(string: String, padding: Int)] = [
-            (string: signedHeading, padding: signedPadding), (string: nameHeading, padding: namePadding), (string: versionHeading, padding: versionPadding),
-            (string: buildHeading, padding: buildPadding), (string: sizeHeading, padding: sizePadding), (string: dateHeading, padding: datePadding)
+            (string: signedHeading, padding: signedPadding),
+            (string: nameHeading, padding: namePadding),
+            (string: versionHeading, padding: versionPadding),
+            (string: buildHeading, padding: buildPadding),
+            (string: sizeHeading, padding: sizePadding),
+            (string: dateHeading, padding: datePadding),
+            (string: compatibleHeading, padding: compatiblePadding)
         ]
 
         var string: String = headerASCIIString(columns: columns)
@@ -48,6 +57,7 @@ extension Sequence where Iterator.Element == [String: Any] {
             let build: String = item["build"] as? String ?? ""
             let size: String = (item["size"] as? Int64 ?? 0).bytesString()
             let date: String = item["date"] as? String ?? ""
+            let compatible: String = (item["compatible"] as? Bool ?? false) ? "True": "False"
 
             let signedPadding: Int = Swift.max(maximumSignedLength - signed.count, 0)
             let namePadding: Int = Swift.max(maximumNameLength - name.count, 0)
@@ -55,10 +65,16 @@ extension Sequence where Iterator.Element == [String: Any] {
             let buildPadding: Int = Swift.max(maximumBuildLength - build.count, 0)
             let sizePadding: Int = Swift.max(maximumSizeLength - size.count, 0)
             let datePadding: Int = Swift.max(maximumDateLength - date.count, 0)
+            let compatiblePadding: Int = Swift.max(maximumCompatibleLength - compatible.count, 0)
 
             let columns: [(string: String, padding: Int)] = [
-                (string: signed, padding: signedPadding), (string: name, padding: namePadding), (string: version, padding: versionPadding),
-                (string: build, padding: buildPadding), (string: size, padding: sizePadding), (string: date, padding: datePadding)
+                (string: signed, padding: signedPadding),
+                (string: name, padding: namePadding),
+                (string: version, padding: versionPadding),
+                (string: build, padding: buildPadding),
+                (string: size, padding: sizePadding),
+                (string: date, padding: datePadding),
+                (string: compatible, padding: compatiblePadding)
             ]
 
             string += rowASCIIString(columns: columns)
@@ -189,7 +205,7 @@ extension Sequence where Iterator.Element == [String: Any] {
     }
 
     func firmwaresCSVString() -> String {
-        "Signed,Name,Version,Build,Size,Date\n" + self.map { $0.firmwareCSVString() }.joined()
+        "Signed,Name,Version,Build,Size,Date,Compatible\n" + self.map { $0.firmwareCSVString() }.joined()
     }
 
     func productsCSVString() -> String {

--- a/Mist/Extensions/Sequence+Extension.swift
+++ b/Mist/Extensions/Sequence+Extension.swift
@@ -67,6 +67,7 @@ extension Sequence where Iterator.Element == [String: Any] {
         return string
     }
 
+    // swiftlint:disable:next function_body_length
     func productsASCIIString() -> String {
 
         let identifierHeading: String = "Identifier"
@@ -75,6 +76,7 @@ extension Sequence where Iterator.Element == [String: Any] {
         let buildHeading: String = "Build"
         let sizeHeading: String = "Size"
         let dateHeading: String = "Date"
+        let compatibleHeading: String = "Compatible"
 
         let maximumIdentifierLength: Int = self.compactMap { $0["identifier"] as? String }.maximumStringLength(comparing: identifierHeading)
         let maximumNameLength: Int = self.compactMap { $0["name"] as? String }.maximumStringLength(comparing: nameHeading)
@@ -82,6 +84,7 @@ extension Sequence where Iterator.Element == [String: Any] {
         let maximumBuildLength: Int = self.compactMap { $0["build"] as? String }.maximumStringLength(comparing: buildHeading)
         let maximumSizeLength: Int = self.compactMap { $0["size"] as? Int64 }.map { $0.bytesString() }.maximumStringLength(comparing: sizeHeading)
         let maximumDateLength: Int = self.compactMap { $0["date"] as? String }.maximumStringLength(comparing: dateHeading)
+        let maximumCompatibleLength: Int = self.compactMap { $0["compatible"] as? Bool }.map { $0 ? "True" : "False" }.maximumStringLength(comparing: compatibleHeading)
 
         let identifierPadding: Int = Swift.max(maximumIdentifierLength - identifierHeading.count, 0)
         let namePadding: Int = Swift.max(maximumNameLength - nameHeading.count, 0)
@@ -89,10 +92,16 @@ extension Sequence where Iterator.Element == [String: Any] {
         let buildPadding: Int = Swift.max(maximumBuildLength - buildHeading.count, 0)
         let sizePadding: Int = Swift.max(maximumSizeLength - sizeHeading.count, 0)
         let datePadding: Int = Swift.max(maximumDateLength - dateHeading.count, 0)
+        let compatiblePadding: Int = Swift.max(maximumCompatibleLength - compatibleHeading.count, 0)
 
         let columns: [(string: String, padding: Int)] = [
-            (string: identifierHeading, padding: identifierPadding), (string: nameHeading, padding: namePadding), (string: versionHeading, padding: versionPadding),
-            (string: buildHeading, padding: buildPadding), (string: sizeHeading, padding: sizePadding), (string: dateHeading, padding: datePadding)
+            (string: identifierHeading, padding: identifierPadding),
+            (string: nameHeading, padding: namePadding),
+            (string: versionHeading, padding: versionPadding),
+            (string: buildHeading, padding: buildPadding),
+            (string: sizeHeading, padding: sizePadding),
+            (string: dateHeading, padding: datePadding),
+            (string: compatibleHeading, padding: compatiblePadding)
         ]
 
         var string: String = headerASCIIString(columns: columns)
@@ -105,6 +114,7 @@ extension Sequence where Iterator.Element == [String: Any] {
             let build: String = item["build"] as? String ?? ""
             let size: String = (item["size"] as? Int64 ?? 0).bytesString()
             let date: String = item["date"] as? String ?? ""
+            let compatible: String = (item["compatible"] as? Bool ?? false) ? "True": "False"
 
             let identifierPadding: Int = Swift.max(maximumIdentifierLength - identifier.count, 0)
             let namePadding: Int = Swift.max(maximumNameLength - name.count, 0)
@@ -112,10 +122,16 @@ extension Sequence where Iterator.Element == [String: Any] {
             let buildPadding: Int = Swift.max(maximumBuildLength - build.count, 0)
             let sizePadding: Int = Swift.max(maximumSizeLength - size.count, 0)
             let datePadding: Int = Swift.max(maximumDateLength - date.count, 0)
+            let compatiblePadding: Int = Swift.max(maximumCompatibleLength - compatible.count, 0)
 
             let columns: [(string: String, padding: Int)] = [
-                (string: identifier, padding: identifierPadding), (string: name, padding: namePadding), (string: version, padding: versionPadding),
-                (string: build, padding: buildPadding), (string: size, padding: sizePadding), (string: date, padding: datePadding)
+                (string: identifier, padding: identifierPadding),
+                (string: name, padding: namePadding),
+                (string: version, padding: versionPadding),
+                (string: build, padding: buildPadding),
+                (string: size, padding: sizePadding),
+                (string: date, padding: datePadding),
+                (string: compatible, padding: compatiblePadding)
             ]
 
             string += rowASCIIString(columns: columns)
@@ -177,7 +193,7 @@ extension Sequence where Iterator.Element == [String: Any] {
     }
 
     func productsCSVString() -> String {
-        "Identifier,Name,Version,Build,Size,Date\n" + self.map { $0.productCSVString() }.joined()
+        "Identifier,Name,Version,Build,Size,Date,Compatible\n" + self.map { $0.productCSVString() }.joined()
     }
 
     func jsonString() throws -> String {

--- a/Mist/Helpers/HTTP.swift
+++ b/Mist/Helpers/HTTP.swift
@@ -187,7 +187,7 @@ struct HTTP {
 
                 let boardIDs: [String] = boardIDsFromDistribution(string)
                 let deviceIDs: [String] = deviceIDsFromDistribution(string)
-                let unsupportedModels: [String] = unsupportedModelsFromDistribution(string)
+                let unsupportedModelIdentifiers: [String] = unsupportedModelIdentifiersFromDistribution(string)
 
                 value["Identifier"] = key
                 value["Name"] = name
@@ -195,7 +195,7 @@ struct HTTP {
                 value["Build"] = build
                 value["BoardIDs"] = boardIDs
                 value["DeviceIDs"] = deviceIDs
-                value["UnsupportedModels"] = unsupportedModels
+                value["UnsupportedModelIdentifiers"] = unsupportedModelIdentifiers
                 value["PostDate"] = dateFormatter.string(from: date)
                 value["DistributionURL"] = distributionURL
 
@@ -279,6 +279,7 @@ struct HTTP {
             .replacingOccurrences(of: "'", with: "")
             .replacingOccurrences(of: " ", with: "")
             .components(separatedBy: ",")
+            .sorted()
     }
 
     /// Returns the macOS Installer **Device ID** values from the provided distribution file string.
@@ -299,15 +300,16 @@ struct HTTP {
             .replacingOccurrences(of: " ", with: "")
             .uppercased()
             .components(separatedBy: ",")
+            .sorted()
     }
 
-    /// Returns the macOS Installer **Unsupported Model** values from the provided distribution file string.
+    /// Returns the macOS Installer **Unsupported Model Identifier** values from the provided distribution file string.
     ///
     /// - Parameters:
     ///   - string: The distribution string.
     ///
-    /// - Returns: An array of **Unsupported Model** strings.
-    private static func unsupportedModelsFromDistribution(_ string: String) -> [String] {
+    /// - Returns: An array of **Unsupported Model Identifier** strings.
+    private static func unsupportedModelIdentifiersFromDistribution(_ string: String) -> [String] {
 
         guard string.contains("nonSupportedModels") else {
             return []
@@ -315,9 +317,10 @@ struct HTTP {
 
         return string.replacingOccurrences(of: "^[\\s\\S]*nonSupportedModels = \\[", with: "", options: .regularExpression)
             .replacingOccurrences(of: ",?\\];[\\s\\S]*$", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "','", with: "'|'")
             .replacingOccurrences(of: "'", with: "")
-            .replacingOccurrences(of: " ", with: "")
-            .components(separatedBy: ",")
+            .components(separatedBy: "|")
+            .sorted()
     }
 
     /// Retrieves the first macOS Installer download match for the provided search string.

--- a/Mist/Helpers/HTTP.swift
+++ b/Mist/Helpers/HTTP.swift
@@ -14,10 +14,11 @@ struct HTTP {
     ///
     /// - Parameters:
     ///   - includeBetas: Set to `true` to prevent skipping of macOS Firmwares in search results.
+    ///   - compatible:   Set to `true` to filter down compatible macOS Firmwares in search results.
     ///   - quiet:        Set to `true` to suppress verbose output.
     ///
     /// - Returns: An array of macOS Firmwares.
-    static func retrieveFirmwares(includeBetas: Bool, quiet: Bool = false) -> [Firmware] {
+    static func retrieveFirmwares(includeBetas: Bool, compatible: Bool, quiet: Bool = false) -> [Firmware] {
         var firmwares: [Firmware] = []
 
         let firmwaresURLString: String = Firmware.firmwaresURL
@@ -70,6 +71,10 @@ struct HTTP {
             firmwares = firmwares.filter { !$0.isBeta }
         }
 
+        if compatible {
+            firmwares = firmwares.filter { $0.compatible }
+        }
+
         firmwares.sort { $0.version == $1.version ? ($0.build.count == $1.build.count ? $0.build > $1.build : $0.build.count > $1.build.count) : $0.version > $1.version }
         return firmwares
     }
@@ -109,10 +114,11 @@ struct HTTP {
     /// - Parameters:
     ///   - catalogURLs:  The Apple Software Update catalog URLs to base the search queries against.
     ///   - includeBetas: Set to `true` to prevent skipping of macOS Installers in search results.
+    ///   - compatible:   Set to `true` to filter down compatible macOS Installers in search results.
     ///   - quiet:        Set to `true` to suppress verbose output.
     ///
     /// - Returns: An array of macOS Installers.
-    static func retrieveProducts(from catalogURLs: [String], includeBetas: Bool, quiet: Bool = false) -> [Product] {
+    static func retrieveProducts(from catalogURLs: [String], includeBetas: Bool, compatible: Bool, quiet: Bool = false) -> [Product] {
         var products: [Product] = []
 
         for catalogURL in catalogURLs {
@@ -146,6 +152,10 @@ struct HTTP {
 
         if !includeBetas {
             products = products.filter { !$0.isBeta }
+        }
+
+        if compatible {
+            products = products.filter { $0.compatible }
         }
 
         products.sort { $0.version == $1.version ? ($0.build.count == $1.build.count ? $0.build > $1.build : $0.build.count > $1.build.count) : $0.version > $1.version }

--- a/Mist/Helpers/HTTP.swift
+++ b/Mist/Helpers/HTTP.swift
@@ -42,6 +42,8 @@ struct HTTP {
                 return []
             }
 
+            let supportedBuilds: [String] = Firmware.supportedBuilds()
+
             for (identifier, device) in devices {
 
                 guard identifier.contains("Mac"),
@@ -50,7 +52,8 @@ struct HTTP {
                     continue
                 }
 
-                for firmwareDictionary in firmwaresArray {
+                for var firmwareDictionary in firmwaresArray {
+                    firmwareDictionary["compatible"] = supportedBuilds.contains(firmwareDictionary["buildid"] as? String ?? "")
                     let firmwareData: Data = try JSONSerialization.data(withJSONObject: firmwareDictionary, options: .prettyPrinted)
                     let firmware: Firmware = try JSONDecoder().decode(Firmware.self, from: firmwareData)
 

--- a/Mist/Helpers/HTTP.swift
+++ b/Mist/Helpers/HTTP.swift
@@ -161,40 +161,41 @@ struct HTTP {
         var products: [Product] = []
         let dateFormatter: DateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
-        var format: PropertyListSerialization.PropertyListFormat = .xml
 
         for (key, value) in dictionary {
 
             guard var value: [String: Any] = value as? [String: Any],
                 let date: Date = value["PostDate"] as? Date,
                 let extendedMetaInfo: [String: Any] = value["ExtendedMetaInfo"] as? [String: Any],
-                extendedMetaInfo["InstallAssistantPackageIdentifiers"] as? [String: Any] != nil else {
-                continue
-            }
-
-            guard let distributions: [String: Any] = value["Distributions"] as? [String: Any],
+                extendedMetaInfo["InstallAssistantPackageIdentifiers"] as? [String: Any] != nil,
+                let distributions: [String: Any] = value["Distributions"] as? [String: Any],
                 let distributionURL: String = distributions["English"] as? String,
                 let url: URL = URL(string: distributionURL) else {
-                !quiet ? PrettyPrint.print("No English distribution found, skipping...") : Mist.noop()
                 continue
             }
 
             do {
-                let string: String = try productPropertyList(from: url)
+                let string: String = try String(contentsOf: url, encoding: .utf8)
 
-                guard let distributionData: Data = string.data(using: .utf8),
-                    let distribution: [String: Any] = try PropertyListSerialization.propertyList(from: distributionData, options: [.mutableContainers], format: &format) as? [String: Any],
-                    let name: String = distribution["NAME"] as? String,
-                    let version: String = distribution["VERSION"] as? String,
-                    let build: String = distribution["BUILD"] as? String else {
+                guard let name: String = nameFromDistribution(string),
+                    let version: String = versionFromDistribution(string),
+                    let build: String = buildFromDistribution(string),
+                    !name.isEmpty && !version.isEmpty && !build.isEmpty else {
                     !quiet ? PrettyPrint.print("No 'Name', 'Version' or 'Build' found, skipping...") : Mist.noop()
                     continue
                 }
+
+                let boardIDs: [String] = boardIDsFromDistribution(string)
+                let deviceIDs: [String] = deviceIDsFromDistribution(string)
+                let unsupportedModels: [String] = unsupportedModelsFromDistribution(string)
 
                 value["Identifier"] = key
                 value["Name"] = name
                 value["Version"] = version
                 value["Build"] = build
+                value["BoardIDs"] = boardIDs
+                value["DeviceIDs"] = deviceIDs
+                value["UnsupportedModels"] = unsupportedModels
                 value["PostDate"] = dateFormatter.string(from: date)
                 value["DistributionURL"] = distributionURL
 
@@ -212,27 +213,111 @@ struct HTTP {
         return products
     }
 
-    /// Converts the contents of a macOS Installer distribution URL into a workable Property List format.
+    /// Returns the macOS Installer **Name** value from the provided distribution file string.
     ///
     /// - Parameters:
-    ///   - url: The macOS Installer distribution URL.
+    ///   - string: The distribution string.
     ///
-    /// - Throws: An `Error` if the contents of the macOS Installer distribution URL are invalid.
-    ///
-    /// - Returns: A macOS Installer Property List.
-    private static func productPropertyList(from url: URL) throws -> String {
-        let distributionString: String = try String(contentsOf: url, encoding: .utf8)
+    /// - Returns: The macOS Installer **Name** string if present, otherwise `nil`.
+    private static func nameFromDistribution(_ string: String) -> String? {
 
-        let name: String = distributionString.replacingOccurrences(of: "^[\\s\\S]*suDisabledGroupID=\"", with: "", options: .regularExpression)
+        guard string.contains("suDisabledGroupID") else {
+            return nil
+        }
+
+        return string.replacingOccurrences(of: "^[\\s\\S]*suDisabledGroupID=\"", with: "", options: .regularExpression)
             .replacingOccurrences(of: "\"[\\s\\S]*$", with: "", options: .regularExpression)
             .replacingOccurrences(of: "Install ", with: "")
+    }
 
-        let string: String = distributionString.replacingOccurrences(of: "^[\\s\\S]*<auxinfo>\\s*", with: "", options: .regularExpression)
-            .replacingOccurrences(of: "\\s*</auxinfo>[\\s\\S]*$", with: "", options: .regularExpression)
-            .replacingOccurrences(of: "</dict>", with: "<key>NAME</key><string>\(name)</string></dict>")
-            .wrappedInPropertyList()
+    /// Returns the macOS Installer **Version** value from the provided distribution file string.
+    ///
+    /// - Parameters:
+    ///   - string: The distribution string.
+    ///
+    /// - Returns: The macOS Installer **Version** string if present, otherwise `nil`.
+    private static func versionFromDistribution(_ string: String) -> String? {
 
-        return string
+        guard string.contains("<key>VERSION</key>") else {
+            return nil
+        }
+
+        return string.replacingOccurrences(of: "^[\\s\\S]*<key>VERSION<\\/key>\\s*<string>", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "<\\/string>[\\s\\S]*$", with: "", options: .regularExpression)
+    }
+
+    /// Returns the macOS Installer **Build** value from the provided distribution file string.
+    ///
+    /// - Parameters:
+    ///   - string: The distribution string.
+    ///
+    /// - Returns: The macOS Installer **Build** string if present, otherwise `nil`.
+    private static func buildFromDistribution(_ string: String) -> String? {
+
+        guard string.contains("<key>BUILD</key>") else {
+            return nil
+        }
+
+        return string.replacingOccurrences(of: "^[\\s\\S]*<key>BUILD<\\/key>\\s*<string>", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "<\\/string>[\\s\\S]*$", with: "", options: .regularExpression)
+    }
+
+    /// Returns the macOS Installer **Board ID** values from the provided distribution file string.
+    ///
+    /// - Parameters:
+    ///   - string: The distribution string.
+    ///
+    /// - Returns: An array of **Board ID** strings.
+    private static func boardIDsFromDistribution(_ string: String) -> [String] {
+
+        guard string.contains("supportedBoardIDs") || string.contains("boardIds") else {
+            return []
+        }
+
+        return string.replacingOccurrences(of: "^[\\s\\S]*(supportedBoardIDs|boardIds) = \\[", with: "", options: .regularExpression)
+            .replacingOccurrences(of: ",?\\];[\\s\\S]*$", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "'", with: "")
+            .replacingOccurrences(of: " ", with: "")
+            .components(separatedBy: ",")
+    }
+
+    /// Returns the macOS Installer **Device ID** values from the provided distribution file string.
+    ///
+    /// - Parameters:
+    ///   - string: The distribution string.
+    ///
+    /// - Returns: An array of **Device ID** strings.
+    private static func deviceIDsFromDistribution(_ string: String) -> [String] {
+
+        guard string.contains("supportedDeviceIDs") else {
+            return []
+        }
+
+        return string.replacingOccurrences(of: "^[\\s\\S]*supportedDeviceIDs = \\[", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "\\];[\\s\\S]*$", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "'", with: "")
+            .replacingOccurrences(of: " ", with: "")
+            .uppercased()
+            .components(separatedBy: ",")
+    }
+
+    /// Returns the macOS Installer **Unsupported Model** values from the provided distribution file string.
+    ///
+    /// - Parameters:
+    ///   - string: The distribution string.
+    ///
+    /// - Returns: An array of **Unsupported Model** strings.
+    private static func unsupportedModelsFromDistribution(_ string: String) -> [String] {
+
+        guard string.contains("nonSupportedModels") else {
+            return []
+        }
+
+        return string.replacingOccurrences(of: "^[\\s\\S]*nonSupportedModels = \\[", with: "", options: .regularExpression)
+            .replacingOccurrences(of: ",?\\];[\\s\\S]*$", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "'", with: "")
+            .replacingOccurrences(of: " ", with: "")
+            .components(separatedBy: ",")
     }
 
     /// Retrieves the first macOS Installer download match for the provided search string.

--- a/Mist/Helpers/Hardware.swift
+++ b/Mist/Helpers/Hardware.swift
@@ -1,0 +1,82 @@
+//
+//  Hardware.swift
+//  Mist
+//
+//  Created by Nindi Gill on 31/5/2022.
+//
+
+import Foundation
+
+/// Hardware Struct used to retrieve Hardware information.
+struct Hardware {
+
+    /// Hardware Architecture (arm64 or x86_64).
+    static var architecture: String? {
+
+        guard let cString: UnsafePointer<CChar> = NXGetLocalArchInfo().pointee.name else {
+            return nil
+        }
+
+        return String(cString: cString)
+    }
+
+    /// Hardware Board ID (Intel).
+    static var boardID: String? {
+
+        guard let architecture: String = architecture else {
+            return nil
+        }
+
+        return architecture.contains("x86_64") ? registryProperty(for: "board-id") : nil
+    }
+    /// Hardware Device ID (Apple Silicon or Intel T2).
+    static var deviceID: String? {
+
+        guard let architecture: String = architecture else {
+            return nil
+        }
+
+        if architecture.contains("x86_64") {
+            return registryProperty(for: "bridge-model")?.uppercased()
+        } else {
+            return registryProperty(for: "compatible")?.components(separatedBy: "\0").first?.uppercased()
+        }
+    }
+    /// Hardware Model Identifier (Apple Silicon or Intel).
+    static var modelIdentifier: String? {
+        registryProperty(for: "model")
+    }
+
+    /// Retrieves the IOKit Registry **IOPlatformExpertDevice** entity property for the provided key.
+    ///
+    /// - Parameters:
+    ///   - key: The key for the entity property.
+    ///
+    /// - Returns: The entity property for the provided key.
+    private static func registryProperty(for key: String) -> String? {
+
+        let entry: io_service_t = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
+
+        defer {
+            IOObjectRelease(entry)
+        }
+
+        var properties: Unmanaged<CFMutableDictionary>?
+
+        guard IORegistryEntryCreateCFProperties(entry, &properties, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+            let properties: Unmanaged<CFMutableDictionary> = properties else {
+            return nil
+        }
+
+        let nsDictionary: NSDictionary = properties.takeRetainedValue() as NSDictionary
+
+        guard let dictionary: [String: Any] = nsDictionary as? [String: Any],
+            dictionary.keys.contains(key),
+            let data: Data = IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0).takeRetainedValue() as? Data,
+            let string: String = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return string.trimmingCharacters(in: CharacterSet(["\0"]))
+    }
+}

--- a/Mist/Model/Product.swift
+++ b/Mist/Model/Product.swift
@@ -18,7 +18,7 @@ struct Product: Decodable {
         case packages = "Packages"
         case boardIDs = "BoardIDs"
         case deviceIDs = "DeviceIDs"
-        case unsupportedModels = "UnsupportedModels"
+        case unsupportedModelIdentifiers = "UnsupportedModelIdentifiers"
     }
 
     let identifier: String
@@ -30,27 +30,38 @@ struct Product: Decodable {
     let packages: [Package]
     let boardIDs: [String]
     let deviceIDs: [String]
-    let unsupportedModels: [String]
+    let unsupportedModelIdentifiers: [String]
     var compatible: Bool {
         // Board ID (Intel)
-        if !boardIDs.isEmpty,
-            let boardID: String = Hardware.boardID,
+        if let boardID: String = Hardware.boardID,
+            !boardIDs.isEmpty,
             !boardIDs.contains(boardID) {
             return false
         }
 
         // Device ID (Apple Silicon or Intel T2)
-        if !deviceIDs.isEmpty,
+        // macOS Big Sur 11 or newer
+        if version.range(of: "^1[1-9]\\.", options: .regularExpression) != nil,
             let deviceID: String = Hardware.deviceID,
+            !deviceIDs.isEmpty,
             !deviceIDs.contains(deviceID) {
             return false
         }
 
         // Model Identifier (Apple Silicon or Intel)
-        if !unsupportedModels.isEmpty,
-            let modelIdentifier: String = Hardware.modelIdentifier,
-            unsupportedModels.contains(modelIdentifier) {
-            return false
+        // macOS Catalina 10.15 or older
+        if version.range(of: "^10\\.", options: .regularExpression) != nil {
+
+            if let architecture: String = Hardware.architecture,
+                architecture.contains("arm64") {
+                return false
+            }
+
+            if let modelIdentifier: String = Hardware.modelIdentifier,
+                !unsupportedModelIdentifiers.isEmpty,
+                unsupportedModelIdentifiers.contains(modelIdentifier) {
+                return false
+            }
         }
 
         return true

--- a/Mist/Model/Product.swift
+++ b/Mist/Model/Product.swift
@@ -16,6 +16,9 @@ struct Product: Decodable {
         case date = "PostDate"
         case distribution = "DistributionURL"
         case packages = "Packages"
+        case boardIDs = "BoardIDs"
+        case deviceIDs = "DeviceIDs"
+        case unsupportedModels = "UnsupportedModels"
     }
 
     let identifier: String
@@ -25,6 +28,33 @@ struct Product: Decodable {
     let date: String
     let distribution: String
     let packages: [Package]
+    let boardIDs: [String]
+    let deviceIDs: [String]
+    let unsupportedModels: [String]
+    var compatible: Bool {
+        // Board ID (Intel)
+        if !boardIDs.isEmpty,
+            let boardID: String = Hardware.boardID,
+            !boardIDs.contains(boardID) {
+            return false
+        }
+
+        // Device ID (Apple Silicon or Intel T2)
+        if !deviceIDs.isEmpty,
+            let deviceID: String = Hardware.deviceID,
+            !deviceIDs.contains(deviceID) {
+            return false
+        }
+
+        // Model Identifier (Apple Silicon or Intel)
+        if !unsupportedModels.isEmpty,
+            let modelIdentifier: String = Hardware.modelIdentifier,
+            unsupportedModels.contains(modelIdentifier) {
+            return false
+        }
+
+        return true
+    }
     var allDownloads: [Package] {
         [Package(url: distribution, size: 0, integrityDataURL: nil, integrityDataSize: nil)] + packages.sorted { $0.filename < $1.filename }
     }
@@ -41,7 +71,8 @@ struct Product: Decodable {
             "version": version,
             "build": build,
             "size": size,
-            "date": date
+            "date": date,
+            "compatible": compatible
         ]
     }
     var exportDictionary: [String: Any] {
@@ -52,6 +83,7 @@ struct Product: Decodable {
             "build": build,
             "size": size,
             "date": date,
+            "compatible": compatible,
             "distribution": distribution,
             "packages": packages.map { $0.dictionary },
             "beta": isBeta


### PR DESCRIPTION
Fixes #65

Adds `--compatible` flag support for:
* `mist list firmware --compatible`
* `mist list installer --compatible`
* `mist download firmware --compatible`
* `mist download installer --compatible`