### PR TITLE
Fixes #189 - macOS 15.6+ installer creation failure

### DIFF
--- a/Mist/Helpers/InstallerCreator.swift
+++ b/Mist/Helpers/InstallerCreator.swift
@@ -28,11 +28,11 @@ enum InstallerCreator {
 
             packageURL = URL(fileURLWithPath: "/Volumes/Install \(installer.name)").appendingPathComponent(package.filename.replacingOccurrences(of: ".dmg", with: ".pkg"))
         } else {
-            guard let url: URL = URL(string: installer.distributionURL) else {
+            guard URL(string: installer.distributionURL) != nil else {
                 throw MistError.invalidURL(installer.distributionURL)
             }
 
-            packageURL = URL(fileURLWithPath: cacheDirectory).appendingPathComponent(installer.id).appendingPathComponent(url.lastPathComponent)
+            packageURL = URL(fileURLWithPath: cacheDirectory).appendingPathComponent(installer.id).appendingPathComponent("InstallAssistant.pkg")
         }
 
         try await DirectoryRemover.remove(installer.temporaryInstallerURL)


### PR DESCRIPTION
Changed installer package path to use InstallAssistant.pkg instead of the distribution file (.dist). This resolves the "Opened package is not the same at install time" error that occurs on macOS 15.6 and newer. Addresses Issue #189 and similar problems (#188 #184)

Tested (and properly generated without errors):

- macOS Sequoia 15.6.1 (24G90)
- macOS Sonoma 14.8 (23J21)
- macOS Ventura 13.7.8 (22H730)
- macOS Monterey 12.7.4 (21H1123)
- macOS Big Sur 11.7.10 (20G1427)

Untested:

- macOS Tahoe 26.x

But, if that was the same root cause, it will most likely also be solved.