### PR TITLE
Fix 10.13-10.15 installer creation on 15.6+ hosts

### DIFF
--- a/Mist/Helpers/InstallerCreator.swift
+++ b/Mist/Helpers/InstallerCreator.swift
@@ -19,6 +19,7 @@ enum InstallerCreator {
     ///
     /// - Throws: A `MistError` if the downloaded macOS Installer fails to generate.
     static func create(_ installer: Installer, mountPoint: URL, cacheDirectory: String) async throws {
+        let installerCacheDirectoryURL = URL(fileURLWithPath: cacheDirectory).appendingPathComponent(installer.id)
         let packageURL: URL
 
         if installer.sierraOrOlder {
@@ -29,36 +30,61 @@ enum InstallerCreator {
             packageURL = URL(fileURLWithPath: "/Volumes/Install \(installer.name)").appendingPathComponent(package.filename.replacingOccurrences(of: ".dmg", with: ".pkg"))
         } else {
             if installer.containsInstallAssistantPackage {
-                packageURL = URL(fileURLWithPath: cacheDirectory).appendingPathComponent(installer.id).appendingPathComponent("InstallAssistant.pkg")
+                packageURL = installerCacheDirectoryURL.appendingPathComponent("InstallAssistant.pkg")
+            } else if installer.containsInstallAssistantAutoPackage {
+                packageURL = installerCacheDirectoryURL.appendingPathComponent("InstallAssistantAuto.pkg")
             } else {
                 guard let url: URL = URL(string: installer.distributionURL) else {
                     throw MistError.invalidURL(installer.distributionURL)
                 }
 
-                packageURL = URL(fileURLWithPath: cacheDirectory).appendingPathComponent(installer.id).appendingPathComponent(url.lastPathComponent)
+                packageURL = installerCacheDirectoryURL.appendingPathComponent(url.lastPathComponent)
             }
         }
 
         try await DirectoryRemover.remove(installer.temporaryInstallerURL)
 
-        var argumentsArrays: [[String]] = [
-            ["installer", "-pkg", packageURL.path, "-target", mountPoint.path]
-        ]
-
-        // workaround for macOS High Sierra 10.13, macOS Mojave 10.14 and macOS Catalina 10.15
-        if installer.highSierraOrNewer, !installer.bigSurOrNewer {
+        var argumentsArrays: [[String]] = []
+        
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        if
+            installer.highSierraOrNewer, !installer.bigSurOrNewer,
+            (osVersion.majorVersion > 15 || (osVersion.majorVersion == 15 && osVersion.minorVersion >= 6)) {
+            // Use special method for macOS >= 15.6
+            let installAssistantExpansionDirectory = installerCacheDirectoryURL.appendingPathComponent("InstallAssistantAuto")
+            let payloadInstallerApp = installAssistantExpansionDirectory.appendingPathComponent("Payload/Install \(installer.name).app")
+            let sharedSupportDirectory = payloadInstallerApp.appendingPathComponent("Contents/SharedSupport")
             argumentsArrays += [
-                ["ditto", "/Applications/Install \(installer.name).app", "\(mountPoint.path)/Applications/Install \(installer.name).app"],
-                ["rm", "-r", "/Applications/Install \(installer.name).app"]
+                ["pkgutil", "--expand-full", packageURL.path, installAssistantExpansionDirectory.path],
+                ["cp", installerCacheDirectoryURL.appendingPathComponent("AppleDiagnostics.chunklist").path, sharedSupportDirectory.path],
+                ["cp", installerCacheDirectoryURL.appendingPathComponent("AppleDiagnostics.dmg").path, sharedSupportDirectory.path],
+                ["cp", installerCacheDirectoryURL.appendingPathComponent("BaseSystem.chunklist").path, sharedSupportDirectory.path],
+                ["cp", installerCacheDirectoryURL.appendingPathComponent("BaseSystem.dmg").path, sharedSupportDirectory.path],
+                ["cp", installerCacheDirectoryURL.appendingPathComponent("InstallESDDmg.pkg").path, sharedSupportDirectory.appendingPathComponent("InstallESD.dmg").path],
+                ["ditto", payloadInstallerApp.path, mountPoint.appendingPathComponent("Applications").appendingPathComponent("Install \(installer.name).app").path],
+                ["rm", "-r", installAssistantExpansionDirectory.path]
             ]
-        }
-
-        // workaround for macOS Catalina 10.15 and newer
-        if installer.catalinaOrNewer {
+        } else {
+            // Use /usr/sbin/installer for macOS < 15.6
             argumentsArrays += [
-                ["ditto", "\(mountPoint.path)Applications", "\(mountPoint.path)/Applications"],
-                ["rm", "-r", "\(mountPoint.path)Applications"]
+                ["installer", "-pkg", packageURL.path, "-target", mountPoint.path]
             ]
+            
+            // workaround for macOS High Sierra 10.13, macOS Mojave 10.14 and macOS Catalina 10.15
+            if installer.highSierraOrNewer, !installer.bigSurOrNewer {
+                argumentsArrays += [
+                    ["ditto", "/Applications/Install \(installer.name).app", "\(mountPoint.path)/Applications/Install \(installer.name).app"],
+                    ["rm", "-r", "/Applications/Install \(installer.name).app"]
+                ]
+            }
+
+            // workaround for macOS Catalina 10.15 and newer
+            if installer.catalinaOrNewer {
+                argumentsArrays += [
+                    ["ditto", "\(mountPoint.path)Applications", "\(mountPoint.path)/Applications"],
+                    ["rm", "-r", "\(mountPoint.path)Applications"]
+                ]
+            }
         }
 
         let variables: [String: String] = ["CM_BUILD": "CM_BUILD"]

--- a/Mist/Model/Installer.swift
+++ b/Mist/Model/Installer.swift
@@ -740,6 +740,10 @@ struct Installer: Decodable, Hashable, Identifiable {
     var containsInstallAssistantPackage: Bool {
         packages.contains { $0.filename == "InstallAssistant.pkg" }
     }
+    
+    var containsInstallAssistantAutoPackage: Bool {
+        packages.contains { $0.filename == "InstallAssistantAuto.pkg" }
+    }
 
     var temporaryDiskImageMountPointURL: URL {
         URL(fileURLWithPath: "/Volumes/\(id)")


### PR DESCRIPTION
This PR resolves https://github.com/ninxsoft/Mist/issues/198 (and other related issues) by implementing a workaround method for generating installer applications for macOS High Sierra 10.13 through macOS Catalina 10.15 on hosts running macOS Sequoia 15.6 and later.

I discovered the method used on the [InsanelyMac forum](https://www.insanelymac.com/forum/topic/345251-release-macos-catalina-10157/#findComment-2747592). An honorable mention is owed to [Luming Yin's macOS installer index page](https://www.lumingyin.com/mac/) for another viable method, but I found that it was much more difficult to cleanly implement that method as it required setting environment variables (which doesn't work well when executing shell commands via the Mist helper tool).

Combined with my patch from https://github.com/ninxsoft/Mist/pull/229, this should allow Apple Silicon hosts to generate installer applications, ISOs, and bootable USBs for all versions from OS X Mavericks 10.9 onward.

I will submit a separate PR for [mist-cli](https://github.com/ninxsoft/mist-cli) to port this patch at a later date.