### PR TITLE
Clamp download progress to 100%

### DIFF
--- a/Mist/Helpers/DownloadManager.swift
+++ b/Mist/Helpers/DownloadManager.swift
@@ -12,7 +12,9 @@ class DownloadManager: NSObject, ObservableObject {
     private var task: URLSessionDownloadTask?
     private var progress: Progress = .init()
     var currentValue: Double {
-        progress.fractionCompleted
+        // ponytail: clamp to 1.0 - Progress.fractionCompleted can exceed 1.0 when the
+        // server sends more bytes than the expected Content-Length (e.g. resumed downloads)
+        min(progress.fractionCompleted, 1)
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length


### PR DESCRIPTION
## Summary

Fixes #222 ("More than 100%").

`Progress.fractionCompleted` can exceed `1.0` when the server delivers more bytes than the expected `Content-Length` (e.g. on resumed downloads). The activity view then renders values like `103.00% completed`. SwiftUI's `ProgressView` clamps the bar internally, but the percentage label and the "X of Y bytes" label read the raw value directly, so they overshoot.

## Fix

Clamp `currentValue` at its single source in `DownloadManager` so every consumer (progress bar, percentage text, byte count) stays capped at 100%:

```swift
var currentValue: Double {
    min(progress.fractionCompleted, 1)
}
```

## Verification

Reproduced the exact scenario with the same `Progress` API (completed 103 of expected 100 units):

```
old (buggy):  103.00% completed
new (fixed):  100.00% completed
```

Valid mid-download values (e.g. 50%) pass through unchanged.